### PR TITLE
[CI] pin sqlalchemy

### DIFF
--- a/ci/requirements-3.6-dev.yml
+++ b/ci/requirements-3.6-dev.yml
@@ -45,7 +45,7 @@ dependencies:
   - rtree
   - ruamel.yaml
   - shapely
-  - sqlalchemy>=1.1
+  - sqlalchemy>=1.1,<1.4
   - thrift>=0.9.3
   - thriftpy2  # required for impyla in case of py3
   - toolz

--- a/ci/requirements-3.7-dev.yml
+++ b/ci/requirements-3.7-dev.yml
@@ -45,7 +45,7 @@ dependencies:
   - rtree
   - ruamel.yaml
   - shapely
-  - sqlalchemy>=1.1
+  - sqlalchemy>=1.1,<1.4
   - thrift>=0.9.3
   - thriftpy2  # required for impyla in case of py3
   - toolz

--- a/ci/requirements-3.8-dev.yml
+++ b/ci/requirements-3.8-dev.yml
@@ -49,7 +49,7 @@ dependencies:
   - rtree
   - ruamel.yaml
   - shapely
-  - sqlalchemy>=1.1
+  - sqlalchemy>=1.1,<1.4
   - thrift>=0.9.3
   - thriftpy2  # required for impyla in case of py3
   - toolz


### PR DESCRIPTION
Signed-off-by: Alexander Myskov <alexander.myskov@intel.com>

`intel-ai/ibis/develop` branch is incompatible with `sqlalchemy` >= 1.4 version and throws exception `AttributeError: module 'sqlalchemy' has no attribute 'Binary'` during `ibis` import (`Binary` was replaced with `LargeBinary`).